### PR TITLE
Include RRF in Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Imports:
 	caret,
 	ComplexHeatmap,
 	circlize,
-	grid
+	grid,
+	RRF
 Suggests:
 	knitr,
     rmarkdown


### PR DESCRIPTION
When trying to install TargetedMSQC trhough devtools, I got the Error message: "there is no package called ‘RRF’". So I figured that the CRAN package RRF was missing from the DESCRIPTION file.